### PR TITLE
feat(#3, #4): nginx 서버 컨테이너 올림

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+# FRONT END
+FE_VOL_PATH=/Users/jeseo/test/fe/front/srcs

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+DOCKER_ID := $(shell docker ps -aq)
+DOCKER_IMAGE_ID := $(shell docker images -q)
+DOCKER_VOLUME := $(shell docker volume ls -q)
+PWD := $(shell pwd)
+
+all:
+	sed -i '' 's|^\(FE_VOL_PATH\).*|FE_VOL_PATH=$(PWD)/front/srcs|' "./.env"
+	docker compose up -d
+
+up:
+	docker compose up -d
+
+down:
+	docker compose down
+
+re: fclean
+	make all
+
+fclean:
+	$(if $(DOCKER_ID), docker rm -f $(DOCKER_ID))
+	$(if $(DOCKER_VOLUME), docker volume rm $(DOCKER_VOLUME))
+	docker rmi nginx
+# docker system prune -af
+# $(if $(DOCKER_IMAGE_ID), docker rmi $(DOCKER_IMAGE_ID))
+
+django:
+	docker compose run -it django sh
+
+.PHONY: all up down re fclean

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,23 @@
+version: '3'
+
+services:
+  front:
+    container_name: nginx
+    image: nginx
+    pull_policy: never
+    build: ./front/nginx/
+    restart: always
+    ports:
+      - 8080:8080
+      - 443:443
+    volumes:
+      - fe-vol:/var/www/html/srcs
+
+volumes:
+  fe-vol:
+    driver: local
+    driver_opts:
+      o: bind
+      type: none
+      device: ${FE_VOL_PATH}
+    

--- a/front/nginx/conf/default.conf
+++ b/front/nginx/conf/default.conf
@@ -1,0 +1,42 @@
+server {
+	listen 8080 default_server;
+	listen [::]:8080;
+	
+	root /var/www/html;
+	index srcs/index.html;
+
+	# You may need this to prevent return 404 recursion.
+	location = /404.html {
+		internal;
+	}
+
+    location / {
+        try_files $uri $uri/ @js;
+    }
+
+    location @js {
+        rewrite ^(.*)$ $1.js last;
+    }
+
+	location ~* ^.+\.(jpg|jpeg|png|git|webp|ico|css|js)$ {
+		access_log off;
+		expires 180d;
+	}
+}
+
+# server {
+# 	server_name localhost;
+# 	listen 443 ssl;
+# 	root /var/www/html;
+
+# 	client_max_body_size 13m;
+# 	send_timeout 10s;
+
+# 	index index.html;
+
+# 	location ~* ^.+\.(jpg|jpeg|png|git|webp|ico|css|js)$ {
+# 		access_log off;
+# 		expires 180d;
+# 	}
+
+# }

--- a/front/nginx/conf/nginx.conf
+++ b/front/nginx/conf/nginx.conf
@@ -1,0 +1,65 @@
+# /etc/nginx/nginx.conf
+
+user ts ts;
+
+# Set number of worker processes automatically based on number of CPU cores.
+worker_processes auto;
+
+# Enables the use of JIT for regular expressions to speed-up their processing.
+pcre_jit on;
+
+error_log /var/log/nginx/error.log warn;
+
+# Includes files with directives to load dynamic modules.
+include /etc/nginx/modules/*.conf;
+
+# Include files with config snippets into the root context.
+include /etc/nginx/conf.d/*.conf;
+
+events {
+    # The maximum number of simultaneous connections that can be opened by
+    # a worker process.
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    # Don't tell nginx version to the clients. Default is 'on'.
+    server_tokens off;
+
+    client_max_body_size 1m;
+
+    # Sendfile copies data between one FD and other from within the kernel,
+    # which is more efficient than read() + write(). Default is off.
+    sendfile on;
+
+    # Causes nginx to attempt to send its HTTP response head in one packet,
+    # instead of using partial frames. Default is 'off'.
+    tcp_nopush on;
+    tcp_nodelay on;
+
+    keepalive_timeout 65;
+    types_hash_max_size 2048;
+
+    gzip_vary on;
+
+    # Helper variable for proxying websockets.
+    map $http_upgrade $connection_upgrade {
+            default upgrade;
+            '' close;
+    }
+
+    # Specifies the main log format.
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for"';
+
+    # Sets the path, format, and configuration for a buffered log write.
+	access_log /var/log/nginx/access.log;
+	error_log /var/log/nginx/error.log;
+
+    # Includes virtual hosts configs.
+    include /etc/nginx/http.d/*.conf;
+}

--- a/front/nginx/dockerfile
+++ b/front/nginx/dockerfile
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1
+
+FROM alpine:3.18
+
+ARG SSL_PATH=/etc/ssl/private
+
+RUN apk update && \
+    apk --no-cache add nginx
+    # openssl \
+    # dumb-init && \
+
+RUN adduser -D ts
+
+# RUN openssl genrsa -out ${SSL_PATH}/jeseo.42.fr.key 2048 && \
+#     openssl req -new -key ${SSL_PATH}/jeseo.42.fr.key -out ${SSL_PATH}/jeseo.42.fr.crt \
+#     -subj "/C=KR/ST=Seoul/L=Gaepodong/O=42seoul/OU=Cadet/CN=jeseo.42.kr" && \
+#     openssl x509 -req -days 1000 -in ${SSL_PATH}/jeseo.42.fr.crt -signkey ${SSL_PATH}/jeseo.42.fr.key -out ${SSL_PATH}/jeseo.42.fr.crt && \
+#     chown -R nginx ${SSL_PATH}
+
+WORKDIR /var/www/html
+
+COPY ./conf/nginx.conf /etc/nginx/nginx.conf
+COPY ./conf/default.conf /etc/nginx/http.d/default.conf
+
+EXPOSE 80 443
+ENTRYPOINT ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## 📌 연관된 이슈
- #3 
- #4 

## 📝 작업 내용
정적파일을 서빙해줄 nginx 프론트 서버를 도커파일로 작성하여 컨테이너로 올렸습니다.

## 🌳 작업 브랜치명
`feat/front-server`

## 💬 리뷰 요구사항 (선택)
> nginx 에서 확장자가 없는 경우 js 확장자를 붙여서 붙이도록 했습니다.
> side effect가 우려되지만, 현재로서는 이것이 최선이라고 생각합니다.
