### PR TITLE
desgin: 상태메시지 input의 줄바꿈과 글자 수 제한 완료

### DIFF
--- a/front/srcs/styles.css
+++ b/front/srcs/styles.css
@@ -138,6 +138,10 @@ body {
     padding: 20px;
 }
 
+.state-message {
+    word-break: break-all;
+}
+
 .user-avatar {
     border-radius: 50%;
     width: 12em;
@@ -577,11 +581,10 @@ input[type="range"]::-webkit-slider-thumb {
 }
 
 .edit-user-message-input {
-    /* text-align: start; */
-    vertical-align: top;
+    text-align: center;
     width: 20em;
     height: 7em;
-    /* padding-bottom: 6.5em  */
+    resize: none;
 }
 
 input[type="file"] {

--- a/front/srcs/views/edit/edit_view.html
+++ b/front/srcs/views/edit/edit_view.html
@@ -18,7 +18,7 @@
 	</div>
     <div class="d-flex justify-content-center overflow-hidden my-1">
         <div class="d-flex flex-column align-items-center py-2">
-            <input type="text" class="form-control edit-user-message-input mb-2" placeholder="상태 메시지 입력" aria-label="Status message" aria-describedby="statusMessage">
+            <textarea type="text" class="form-control edit-user-message-input mb-2" placeholder="상태 메시지 입력" style="word-break: break-all;" cols="20" maxlength="45"></textarea>
             <div class="d-flex justify-content-end w-100">
                 <button type="button" class="ms-2 btn btn-primary btn-save">저장</button>
                 <button type="button" class="ms-2 btn btn-primary btn-cancel">취소</button>


### PR DESCRIPTION
## 📌 연관된 이슈
- #76

## 📝 작업 내용
- input을 textarea로 대체하고 설정을 적용시켜 줌.

## 🌳 작업 브랜치명
- `refactor/edit-page`

## 📸 스크린샷 (선택)
<img width="586" alt="image" src="https://github.com/bitbit-Merry-go-round/Transcendence-FE/assets/99523863/d4fc6240-88bb-46c4-9e4a-8f988647b00a">

