### PR TITLE
fix: 뒤로가기 버튼 수동 라우트 #86

### DIFF
--- a/front/srcs/styles.css
+++ b/front/srcs/styles.css
@@ -411,7 +411,7 @@ ul {
     justify-content: center;
     width: 100%;
     height: 100%;
-    background-color: #000a;
+    background-color: #ECEEE7;
     position: fixed;
 }
   
@@ -435,7 +435,7 @@ ul {
 
 .loading-message {
     font-size: 3em;
-    color: white;
+    color: black;
     opacity: 1;
     animation: animate 3s infinite;
 }

--- a/front/srcs/views/edit/edit_view.js
+++ b/front/srcs/views/edit/edit_view.js
@@ -1,5 +1,6 @@
 
 import View from "@/lib/view";
+import { route } from "@/router";
 import httpRequest from "@/utils/httpRequest";
 
 export default class EditView extends View {
@@ -54,7 +55,9 @@ export default class EditView extends View {
         });
         await httpRequest('PATCH', url, body, () => {
           alert(`profile is successfully edited!`);
-          history.back();
+          route({
+            path: 'home'
+          })
         })
         return ;
       }
@@ -68,14 +71,18 @@ export default class EditView extends View {
         });
         await httpRequest('PATCH', url, body, () => {
           alert(`profile is successfully edited!`);
-          history.back();
+          route({
+            path: 'home'
+          })
         })
       });
       reader.readAsBinaryString(file);
     });
 
     btnCancel.addEventListener('click', () => {
-      history.back();
+      route({
+        path: 'home'
+      })
     });
   }
     

--- a/front/srcs/views/friend/friend_view.js
+++ b/front/srcs/views/friend/friend_view.js
@@ -207,7 +207,7 @@ export default class FriendView extends View {
         }
         profileCardModal.style.display = 'flex';
       }, () => {
-        warningMessage.textContent = `'${username}' dose not exist.`;
+        warningMessage.textContent = `'${username}' does not exist.`;
         warningMessage.style.display = 'flex';
 
         setTimeout(() => {

--- a/front/srcs/views/match/match_view.html
+++ b/front/srcs/views/match/match_view.html
@@ -1,7 +1,7 @@
 <match-view class="d-flex flex-column justify-content-center view">
   <div class="d-flex my-5 mx-5 mb-2 d-flex justify-content-between">
     <h1 class="me-5 page-name">Online 1 : 1</h1>
-    <button onclick="history.back()">
+    <button id="move-to-mode">
       <svg xmlns="http://www.w3.org/2000/svg" height="48" viewBox="0 -960 960 960" width="48"><path d="M257-185v-73h322q68 0 116-47.5T743-421q0-67-48-115t-116-48H282l109 109-51 50-196-195 196-196 51 50-109 109h296q98 0 168 69t70 167q0 99-70 167.5T578-185H257Z"/></svg>
     </button>
   </div>

--- a/front/srcs/views/match/match_view.js
+++ b/front/srcs/views/match/match_view.js
@@ -1,5 +1,6 @@
 import Observable from "@/lib/observable";
 import View from "@/lib/view";
+import { NAVIGATE_DRIRECTION, route } from "@/router";
 import httpRequest from "@/utils/httpRequest";
 import { getUsername } from "@/views/game/game_view";
 
@@ -162,6 +163,14 @@ export default class MatchView extends View {
     this._fetchUserInfo();
     this._setPaddleModal();
     this._setItemModal();
+
+    const backBtn = document.getElementById('move-to-mode');
+    backBtn.addEventListener('click', () => {
+      route({
+        path: '/mode',
+        direction: NAVIGATE_DRIRECTION.backward
+      })
+    })
   }
 
   async #setNicknames() {

--- a/front/srcs/views/mode/mode_view.html
+++ b/front/srcs/views/mode/mode_view.html
@@ -2,7 +2,7 @@
   <div class="mb-auto ms-5 mt-5">
     <div class="page-header d-flex justify-content-between">
       <h1 class="page-name mode-view">모드 선택</h1>
-      <button onclick="history.back()">
+      <button id="move-to-home">
         <svg xmlns="http://www.w3.org/2000/svg" height="48" viewBox="0 -960 960 960" width="48"><path d="M257-185v-73h322q68 0 116-47.5T743-421q0-67-48-115t-116-48H282l109 109-51 50-196-195 196-196 51 50-109 109h296q98 0 168 69t70 167q0 99-70 167.5T578-185H257Z"/></svg>
       </button>
     </div>

--- a/front/srcs/views/mode/mode_view.js
+++ b/front/srcs/views/mode/mode_view.js
@@ -1,4 +1,5 @@
 import View from "@/lib/view";
+import { NAVIGATE_DRIRECTION, route } from "@/router";
 
 export default class ModeView extends View {
 
@@ -11,6 +12,14 @@ export default class ModeView extends View {
 
     const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]')
     const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl))
+
+    const backBtn = document.getElementById('move-to-home');
+    backBtn.addEventListener('click', () => {
+      route({
+        path: '/home',
+        direction: NAVIGATE_DRIRECTION.backward
+      })
+    })
   }
 
 }

--- a/front/srcs/views/tournament/tournament_view.html
+++ b/front/srcs/views/tournament/tournament_view.html
@@ -2,7 +2,7 @@
   <div class="mb-auto ms-5 mt-5">
     <div class="page-header d-flex justify-content-between">
       <h1 class="page-name tournament-view">토너먼트</h1>
-      <button onclick="history.back()">
+      <button id="move-to-mode">
         <svg xmlns="http://www.w3.org/2000/svg" height="48" viewBox="0 -960 960 960" width="48"><path d="M257-185v-73h322q68 0 116-47.5T743-421q0-67-48-115t-116-48H282l109 109-51 50-196-195 196-196 51 50-109 109h296q98 0 168 69t70 167q0 99-70 167.5T578-185H257Z"/></svg>
       </button>
     </div>

--- a/front/srcs/views/tournament/tournament_view.js
+++ b/front/srcs/views/tournament/tournament_view.js
@@ -1,4 +1,5 @@
 import View from "@/lib/view";
+import * as GLOBAL from "@/data/global";
 import { NAVIGATE_DRIRECTION, route } from "@/router";
 import { generateRandomName } from "@/utils/random_name";
 import { getUsername } from "../game/game_view";
@@ -181,43 +182,6 @@ export default class TournamentView extends View {
         }
       }
     });
-
-    const backBtn = document.getElementById('move-to-mode');
-    backBtn.addEventListener('click', () => {
-      route({
-        path: '/mode',
-        direction: NAVIGATE_DRIRECTION.backward
-      })
-    })
-
-
-  connectedCallback() {
-    super.connectedCallback();
-    const mapModalBtn = this.querySelector('#confMapBtn');
-    const mapModal = this.querySelector("#map-modal");
-
-    mapModalBtn.addEventListener("click", () => {
-      mapModal.style.display = "block";
-      if (!this.mapModal["allMaps"]) {
-        const allCanvas = mapModal.querySelectorAll("canvas");
-
-        this.mapModal["allMaps"] = allCanvas;
-        allCanvas.forEach(c => {
-          c.addEventListener("click", 
-            () => {
-              mapModal.style.display = "none";
-              this.setMap(c.dataset.map);
-              this.#setParameter("map");
-            }
-          ) 
-        })
-      }
-    })
-
-    this._setRandomPlayerName();
-    this._setPaddleModal();
-    this._setItemModal();
-    this._inputDuplicateCheck();
   }
 
   connectedCallback() {
@@ -247,5 +211,14 @@ export default class TournamentView extends View {
     this._setPaddleModal();
     this._setItemModal();
     this._inputDuplicateCheck();
+
+
+    const backBtn = document.getElementById('move-to-mode');
+    backBtn.addEventListener('click', () => {
+      route({
+        path: '/mode',
+        direction: NAVIGATE_DRIRECTION.backward
+      })
+    })
   }
 }

--- a/front/srcs/views/tournament/tournament_view.js
+++ b/front/srcs/views/tournament/tournament_view.js
@@ -1,5 +1,6 @@
 import View from "@/lib/view";
 import * as GLOBAL from "@/data/global";
+import { NAVIGATE_DRIRECTION, route } from "@/router";
 export default class TournamentView extends View {
 
   /** @param{ string[] } nicknames */
@@ -54,5 +55,13 @@ export default class TournamentView extends View {
         }
       }
     });
+
+    const backBtn = document.getElementById('move-to-mode');
+    backBtn.addEventListener('click', () => {
+      route({
+        path: '/mode',
+        direction: NAVIGATE_DRIRECTION.backward
+      })
+    })
   }
 }


### PR DESCRIPTION
## 📌 연관된 이슈
- #86 

## 📝 작업 내용
- 뒤로가기 버튼(헤더에 있는) 클릭 시 각각 수동으로 라우트

## 🌳 작업 브랜치명
- `fix/edit-confirm-btn`
